### PR TITLE
Throw InvalidEnumArgumentException instead of break foreach loop

### DIFF
--- a/TradeBotyoupin898/Main.cs
+++ b/TradeBotyoupin898/Main.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -36,7 +37,7 @@ namespace TradeBotyoupin898
                 {
                     toDoListHandle(todoList);
                 }
-                catch (System.ComponentModel.InvalidEnumArgumentException NotHandleException)
+                catch (InvalidEnumArgumentException NotHandleException)
                 {
                     Console.WriteLine(NotHandleException);
                 }
@@ -73,7 +74,7 @@ namespace TradeBotyoupin898
                         break;
 
                     default:
-                        throw new System.ComponentModel.InvalidEnumArgumentException(nameof(leaseStatus), (int)leaseStatus, typeof(LeaseStatus));
+                        throw new InvalidEnumArgumentException(nameof(leaseStatus), (int)leaseStatus, typeof(LeaseStatus));
                 }
 
                 Console.WriteLine(todo.CommodityName);

--- a/TradeBotyoupin898/Main.cs
+++ b/TradeBotyoupin898/Main.cs
@@ -32,7 +32,14 @@ namespace TradeBotyoupin898
                     break;
                 }
 
-                toDoListHandle(todoList);
+                try
+                {
+                    toDoListHandle(todoList);
+                }
+                catch (System.ComponentModel.InvalidEnumArgumentException NotHandleException)
+                {
+                    Console.WriteLine(NotHandleException);
+                }
 
                 Thread.Sleep(600000);
             }
@@ -53,7 +60,6 @@ namespace TradeBotyoupin898
                 LeaseStatus leaseStatus = (LeaseStatus)order.LeaseStatus;
 
                 bool needPhoneConfirm = true;
-                bool canHandle = true;
 
                 switch (leaseStatus)
                 {
@@ -67,11 +73,8 @@ namespace TradeBotyoupin898
                         break;
 
                     default:
-                        canHandle = false;
-                        break;
+                        throw new System.ComponentModel.InvalidEnumArgumentException(nameof(leaseStatus), (int)leaseStatus, typeof(LeaseStatus));
                 }
-
-                if (!canHandle) break;
 
                 Console.WriteLine(todo.CommodityName);
 


### PR DESCRIPTION
Since type that haven't deal should consider as error prone, a common flow control `break` shouldn't be use in this case.